### PR TITLE
switch to use of $CFG->tempdir

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -105,7 +105,7 @@ class plagiarism_plugin_urkund extends plagiarism_plugin {
         $userid = $linkarray['userid'];
         if (!empty($linkarray['content'])) {
             $filename = "content-" . $COURSE->id . "-" . $cmid . "-". $userid . ".htm";
-            $filepath = $CFG->dataroot."/temp/urkund/" . $filename;
+            $filepath = $CFG->tempdir."/urkund/" . $filename;
             $file = new stdclass();
             $file->type = "tempurkund";
             $file->filename = $filename;
@@ -450,7 +450,7 @@ class plagiarism_plugin_urkund extends plagiarism_plugin {
     }
 
     /**
-     * called by admin/cron.php 
+     * called by admin/cron.php
      *
      */
     public function cron() {
@@ -599,11 +599,11 @@ class plagiarism_plugin_urkund extends plagiarism_plugin {
 
 function urkund_create_temp_file($cmid, $eventdata) {
     global $CFG;
-    if (!check_dir_exists($CFG->dataroot."/temp/urkund", true, true)) {
-       mkdir($CFG->dataroot."/temp/urkund", 0700);
+    if (!check_dir_exists($CFG->tempdir."/urkund", true, true)) {
+       mkdir($CFG->tempdir."/urkund", 0700);
     }
     $filename = "content-" . $eventdata->courseid . "-" . $cmid . "-" . $eventdata->userid . ".htm";
-    $filepath = $CFG->dataroot."/temp/urkund/" . $filename;
+    $filepath = $CFG->tempdir."/urkund/" . $filename;
     $fd = fopen($filepath, 'wb');   //create if not exist, write binary
     fwrite($fd, $eventdata->content);
     fclose($fd);


### PR DESCRIPTION
Hi,

It would be preferable that all uses of the $CFG->dataroot.'/temp/' is replaced with calls to $CFG->tempdir. This is because on a local machine, $CFG->tempdir gets set to $CFG->dataroot.'/temp/', automatically but on our infrastructure, it can be somewhere different like a tmpfs.

With thanks. 

-Corey
