### PR TITLE
Removed utf-8 doble-encoding of filename

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -903,7 +903,7 @@ function urkund_send_file_to_urkund($plagiarismfile, $plagiarismsettings, $file)
 
     $headers = array('x-urkund-submitter: '.$useremail,
                     'Accept-Language: '.$plagiarismsettings['urkund_lang'],
-                    'x-urkund-filename: '.base64_encode(utf8_encode($filename)),
+                    'x-urkund-filename: '.base64_encode($filename),
                     'Content-Type: '.$mimetype);
 
     // Use Moodle curl wrapper to send file.


### PR DESCRIPTION
The filename is already in utf8 charset. "utf8_encoding" it produces wrong characters in Urkund's reports.
