### PR TITLE
Fixed submit delay

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -911,11 +911,13 @@ function urkund_check_attempt_timeout($plagiarismfile) {
     }
     // Now calculate wait time.
     $i = 0;
+    $delay = 0;
     while ($i < $plagiarismfile->attempt) {
-        if ($wait > $maxsubmissiondelay) {
-            $wait = $maxsubmissiondelay;
+        $delay = $submissiondelay * pow(2,$i);
+        if ($delay > $maxsubmissiondelay) {
+            $delay = $maxsubmissiondelay;
         }
-        $wait = $wait * $plagiarismfile->attempt;
+        $wait += $delay;
         $i++;
     }
     $wait = (int)$wait * 60;


### PR DESCRIPTION
Here's a patch for issue #26.

Now the values are more like what I would expect.
submissions:
attempt: 0, wait: 15
attempt: 1, wait: 30
attempt: 2, wait: 60
attempt: 3, wait: 120
attempt: 4, wait: 180
attempt: 5, wait: 240

status:
attempt: 0, wait: 30
attempt: 1, wait: 60
attempt: 2, wait: 120
attempt: 3, wait: 240
attempt: 4, wait: 480
attempt: 5, wait: 960
attempt: 6, wait: 1920
attempt: 7, wait: 3360
attempt: 8, wait: 4800
attempt: 9, wait: 6240
