### PR TITLE
moved some settings as advanced settings.

### DIFF
--- a/db/access.php
+++ b/db/access.php
@@ -40,4 +40,12 @@ $capabilities = array(
          'teacher' => CAP_ALLOW,
          'manager' => CAP_ALLOW)
     ),
+    'plagiarism/urkund:advancedsettings' => array(
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_COURSE,
+         'legacy' => array(
+         'editingteacher' => CAP_ALLOW,
+         'teacher' => CAP_ALLOW,
+         'manager' => CAP_ALLOW)
+    ),
 );

--- a/lang/en/plagiarism_urkund.php
+++ b/lang/en/plagiarism_urkund.php
@@ -131,3 +131,5 @@ $string['cannotupgradeunprocesseddata'] = '<h1>Cannot upgrade to this version of
  You should revert to an older version of the URKUND plugin, put the site into maintenance mode, run the Moodle Cron process and make sure all old events are cleared. Then try upgrading to this version of the URKUND plugin again.</p>
  <p>For more information see: <a href="https://docs.moodle.org/en/Plagiarism_Prevention_URKUND_Settings#Installation_failed_due_to_unprocessed_data">URKUND Installation failed due to unprocessed data</a></p>';
 $string['timesubmitted'] = 'Time submitted';
+$string['advancedsettings'] = 'URKUND plagiarism plugin: advanced settings';
+$string['urkund:advancedsettings'] = 'Allow the teacher to view advanced module settings from URKUND';

--- a/lib.php
+++ b/lib.php
@@ -493,9 +493,14 @@ class plagiarism_plugin_urkund extends plagiarism_plugin {
             $PAGE->requires->js_init_call('M.plagiarism_urkund.init', array($context->instanceid), true, $jsmodule);
         }
 
-        // Now set some fields as advanced options.
-        $mform->setAdvanced('urkund_allowallfile');
-        $mform->setAdvanced('urkund_selectfiletypes');
+        // show advanced elements only if allowed
+        if (!has_capability('plagiarism/urkund:advancedsettings', $context)) {
+            $mform->removeElement('urkund_advanced_settings');
+            foreach (array('urkund_receiver', 'urkund_studentemail', 'urkund_allowallfile', 'urkund_selectfiletypes') as $name) {
+                $element = $mform->removeElement($name);
+                $mform->addElement('hidden', $name, $element->getValue());
+            }
+        }
 
         // Now handle content restriction settings.
 
@@ -503,12 +508,10 @@ class plagiarism_plugin_urkund extends plagiarism_plugin {
             // I can't see a way to check if a particular checkbox exists
             // elementExists on the checkbox name doesn't work.
             $mform->disabledIf('urkund_restrictcontent', 'assignsubmission_onlinetext_enabled');
-            $mform->setAdvanced('urkund_restrictcontent');
         } else if ($modulename != 'mod_forum') {
             // Forum doesn't need any changes but all other modules should disable this.
             $mform->setDefault('urkund_restrictcontent', 0);
             $mform->hardFreeze('urkund_restrictcontent');
-            $mform->setAdvanced('urkund_restrictcontent');
         }
     }
 
@@ -776,8 +779,6 @@ function urkund_get_form_elements($mform) {
 
     $mform->addElement('header', 'plagiarismdesc', get_string('urkund', 'plagiarism_urkund'));
     $mform->addElement('select', 'use_urkund', get_string("useurkund", "plagiarism_urkund"), $ynoptions);
-    $mform->addElement('text', 'urkund_receiver', get_string("urkund_receiver", "plagiarism_urkund"), array('size' => 40));
-    $mform->addHelpButton('urkund_receiver', 'urkund_receiver', 'plagiarism_urkund');
     $mform->setType('urkund_receiver', PARAM_TEXT);
     $mform->addElement('select', 'urkund_show_student_score',
                        get_string("urkund_show_student_score", "plagiarism_urkund"), $tiioptions);
@@ -789,8 +790,20 @@ function urkund_get_form_elements($mform) {
         $mform->addElement('select', 'urkund_draft_submit',
                            get_string("urkund_draft_submit", "plagiarism_urkund"), $urkunddraftoptions);
     }
+    $contentoptions = array(PLAGIARISM_URKUND_RESTRICTCONTENTNO => get_string('restrictcontentno', 'plagiarism_urkund'),
+                            PLAGIARISM_URKUND_RESTRICTCONTENTFILES => get_string('restrictcontentfiles', 'plagiarism_urkund'),
+                            PLAGIARISM_URKUND_RESTRICTCONTENTTEXT => get_string('restrictcontenttext', 'plagiarism_urkund'));
+    $mform->addElement('select', 'urkund_restrictcontent', get_string('restrictcontent', 'plagiarism_urkund'), $contentoptions);
+    $mform->addHelpButton('urkund_restrictcontent', 'restrictcontent', 'plagiarism_urkund');
+    $mform->setType('urkund_restrictcontent', PARAM_INT);
+    $mform->addElement('header', 'urkund_advanced_settings', get_string('advancedsettings', 'plagiarism_urkund'));
+    $mform->addElement('text', 'urkund_receiver', get_string("urkund_receiver", "plagiarism_urkund"), array('size' => 40));
+    $mform->addHelpButton('urkund_receiver', 'urkund_receiver', 'plagiarism_urkund');
+    $mform->setType('urkund_receiver', PARAM_EMAIL);
     $mform->addElement('select', 'urkund_studentemail', get_string("urkund_studentemail", "plagiarism_urkund"), $ynoptions);
     $mform->addHelpButton('urkund_studentemail', 'urkund_studentemail', 'plagiarism_urkund');
+    $mform->setType('urkund_studentemail', PARAM_INT);
+
 
     $filetypes = urkund_default_allowed_file_types(true);
 
@@ -800,16 +813,10 @@ function urkund_get_form_elements($mform) {
     }
     $mform->addElement('select', 'urkund_allowallfile', get_string('allowallsupportedfiles', 'plagiarism_urkund'), $ynoptions);
     $mform->addHelpButton('urkund_allowallfile', 'allowallsupportedfiles', 'plagiarism_urkund');
+    $mform->setType('urkund_allowallfile', PARAM_INT);
     $mform->addElement('select', 'urkund_selectfiletypes', get_string('restrictfiles', 'plagiarism_urkund'),
                        $supportedfiles, array('multiple' => true));
-
-    $contentoptions = array(PLAGIARISM_URKUND_RESTRICTCONTENTNO => get_string('restrictcontentno', 'plagiarism_urkund'),
-                            PLAGIARISM_URKUND_RESTRICTCONTENTFILES => get_string('restrictcontentfiles', 'plagiarism_urkund'),
-                            PLAGIARISM_URKUND_RESTRICTCONTENTTEXT => get_string('restrictcontenttext', 'plagiarism_urkund'));
-
-    $mform->addElement('select', 'urkund_restrictcontent', get_string('restrictcontent', 'plagiarism_urkund'), $contentoptions);
-    $mform->addHelpButton('urkund_restrictcontent', 'restrictcontent', 'plagiarism_urkund');
-
+    $mform->setType('urkund_selectfiletypes', PARAM_TAGLIST);
 }
 
 /**

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2015122907;
+$plugin->version = 2017021700;
 $plugin->requires = 2014041100.00;
 $plugin->cron     = 86400; // Cron function no longer used.
 $plugin->component = 'plagiarism_urkund';


### PR DESCRIPTION
Hi!

Here are a possible enhancement you may be interested in.

This enhancement is focused on simplicity from an administration point of view. We have sepparated module and default settings into two sets: normal and advanced settings. We also have added an additional capability to see the advanced settings (enabled by default to teachers and editing teachers and managers, to keep the behaviour as much close as possible to the current operation).

We needed this sepparation of settings in order to make things easier for our instution, administrators and professors. In our case, we will have a single account (unique receiver email address), so there is no need to show professors that email, which professors could modify and make the Urkund integration do not work on those Moodle activities.

Since we needed this change, and do not modify the current operation, we believe it can be of your interest to be integrated. This change, actually, adds more flexibility.

By default, after this update, professors will see something similar to this image on module settings:

![image](https://cloud.githubusercontent.com/assets/2048296/23066936/44754326-f51d-11e6-8848-42a5cc91073d.png)

The above image is also applicable for default settings on plugin settings (administration section).

If we remove the capability of accessing to advanced settings, professors will see only these options on module seetings:

![image](https://cloud.githubusercontent.com/assets/2048296/23066914/268f82d6-f51d-11e6-996f-1ba785cba752.png)

Hoping you like it. 

Looking forward to hear from you.

Regards,

Jordi