### PR TITLE
allow restriction access settings with hidden urkund settings.

### DIFF
--- a/checkreceiver.js
+++ b/checkreceiver.js
@@ -77,6 +77,12 @@ M.plagiarism_urkund.init = function(Y, contextid) {
     };
 
     var receiver = Y.one('#id_urkund_receiver');
+    if (null == receiver) {
+        // there is nothing to check.
+        // for cases where receiver setting is advanced and
+        // hidden to users via capabilities.
+        return;
+    }
     // Validate existing content.
     check_urkund_receiver(Y, receiver, contextid);
     // Validate on change.

--- a/lib.php
+++ b/lib.php
@@ -477,13 +477,14 @@ class plagiarism_plugin_urkund extends plagiarism_plugin {
             foreach ($plagiarismelements as $element) {
                 $mform->addElement('hidden', $element);
             }
-            $mform->setType('use_urkund', PARAM_INT);
-            $mform->setType('urkund_show_student_score', PARAM_INT);
-            $mform->setType('urkund_show_student_report', PARAM_INT);
-            $mform->setType('urkund_draft_submit', PARAM_INT);
-            $mform->setType('urkund_receiver', PARAM_TEXT);
-            $mform->setType('urkund_studentemail', PARAM_INT);
         }
+        $mform->setType('use_urkund', PARAM_INT);
+        $mform->setType('urkund_show_student_score', PARAM_INT);
+        $mform->setType('urkund_show_student_report', PARAM_INT);
+        $mform->setType('urkund_draft_submit', PARAM_INT);
+        $mform->setType('urkund_receiver', PARAM_TEXT);
+        $mform->setType('urkund_studentemail', PARAM_INT);
+
         // Now set defaults.
         foreach ($plagiarismelements as $element) {
             $defaultelement = $element.'_'.str_replace('mod_', '', $modulename);


### PR DESCRIPTION
When having urkund receiver setting hidden due to advanced urkund settings and capabilities configuration, there is no such form element and javascript init process hangs.

Additionally, fixed the required "setType" for each form field. This is something I already did on some other PR, but not included yet.

This PR solved all this stated at #108.

Thanks for your time.