### PR TITLE
lib.php: get correct context for coursemodule settings page

### DIFF
--- a/checkreceiver.js
+++ b/checkreceiver.js
@@ -90,7 +90,7 @@ M.plagiarism_urkund.init = function(Y, contextid) {
                 success: function(tid, response) {
                     var jsondata = Y.JSON.parse(response.responseText);
                     var form = Y.one('#id_urkund_receiver');
-                    if (jsondata.error == true) {
+                    if (typeof jsondata.error != 'undefined') {
                         form.insert(invalid, 'after');
                     } else {
                         form.set('value', jsondata.receiver);

--- a/lib.php
+++ b/lib.php
@@ -913,7 +913,7 @@ function plagiarism_urkund_coursemodule_standard_elements($formwrapper, $mform) 
     if (empty($plagiarismsettings[$modname])) {
         return;
     }
-    $context = $formwrapper->get_context();
+    $context = context_course::instance($formwrapper->get_course()->id);
     if (!empty($cmid)) {
         $plagiarismvalues = $DB->get_records_menu('plagiarism_urkund_config', array('cm' => $cmid), '', 'name, value');
         // If this is an older assignment, it may not have a resubmit_on_close setting in place.
@@ -993,7 +993,7 @@ function plagiarism_urkund_coursemodule_standard_elements($formwrapper, $mform) 
             'fullpath' => '/plagiarism/urkund/checkreceiver.js',
             'requires' => array('json'),
         );
-        $PAGE->requires->js_init_call('M.plagiarism_urkund.init', array($context->instanceid), true, $jsmodule);
+        $PAGE->requires->js_init_call('M.plagiarism_urkund.init', array($formwrapper->get_course()->id), true, $jsmodule);
     }
 
     // Show advanced elements only if allowed.


### PR DESCRIPTION
This is caused by the move to the standard_elements moodle function which switched the context from the course to the course module
Pull request that caused this issue is #127 

I switched $context to also use course context, however you may want to keep this on course module? Not sure.
I have also added a better check in checkreceiver.js if it does fail as the previous check didn't work when it was passed an unexpected value in the error value.